### PR TITLE
chore(Layout): apply new layout structure to pages

### DIFF
--- a/Documentation/Explanations/README.md
+++ b/Documentation/Explanations/README.md
@@ -1,4 +1,6 @@
-[Home](../../README.md) &gt; Explanations
+&gt; [Home](../../README.md)
+
+# Explanations
 
 Common problems and solutions in spatial computing explained along with how VRTK can be utilized to overcome issues with little effort. They also provide an insight into the inner workings of the VRTK features.
 

--- a/Documentation/HowToGuides/Basics/AddingTheUnityXRCameraRig/README.md
+++ b/Documentation/HowToGuides/Basics/AddingTheUnityXRCameraRig/README.md
@@ -1,21 +1,31 @@
-[Home](../../../../README.md) &gt; [How-to Guides](../../README.md) &gt; [Basics](../README.md) &gt; Adding The UnityXRCameraRig
+&gt; [Home](../../../../README.md) &gt; [How-to Guides](../../README.md) &gt; [Basics](../README.md)
 
-  > Reading time: 2 minutes
+# Adding The UnityXRCameraRig
 
-### Introduction
+## Introduction
 
-The UnityXR CameraRig prefab provides a camera that tracks the HMD rotation and position along with any available XR controllers.
+  > * Level: Beginner
+  >
+  > * Reading Time: 2 minutes
+  >
+  > * Checked with: Unity 2018.1
 
-### Useful definitions
+The UnityXR CameraRig helper prefab provides a camera that tracks the HMD rotation and position along with any available XR controllers.
+
+The outcome of this How-To Guide is to learn how to add the UnityXR CameraRig prefab to the scene and configure it for the tracking space type you require.
+
+## Useful definitions
 
 * `HMD` - A Head Mounted Display is a display device that is worn on the head, usually a VR/AR Headset.
 * `CameraRig` - A GameObject that contains a HMD representation and controller representations.
 * `6 degrees of freedom` - An object that is real world tracked in the 3 rotational axes and 3 directional axes, also known as room scale tracking.
 * `3 degrees of freedom` - An object that is real world tracked in only the 3 rotational axes and no directional axes, also known as stationary tracking.
 
-### Prerequisites
+## Prerequisites
 
 * Add [VRTK.Unity.Core] to your Unity3d project.
+
+## Let's Start
 
 ### Step 1
 
@@ -39,13 +49,13 @@ Select the `UnityXRCameraRig` GameObject in the Unity3d Hierarchy window and cha
 
 ![Unity XR Configuration Tracking Space Type](assets/images/UnityXRConfigurationTrackingSpaceType.png)
 
-### Complete
+### Done
 
 Now you have a UnityXR CameraRig in your scene. If you play your scene you will see that the game Main Camera is tracking the XR HMD and if there is a connected left and/or right XR controller then they will be tracking the Left/Right Anchors of the UnityXR CameraRig.
 
 ![UnityXRCameraRig In Scene](assets/images/UnityXRCameraRigInScene.png)
 
-### Suggested Reading
+## Related Reading
 
 * Follow up tutorials coming soon...
 

--- a/Documentation/HowToGuides/Basics/README.md
+++ b/Documentation/HowToGuides/Basics/README.md
@@ -1,4 +1,6 @@
-[Home](../../../README.md) &gt; [How-to Guides](../README.md) &gt; Basics
+&gt; [Home](../../../README.md) &gt; [How-to Guides](../README.md)
+
+# Basics
 
 Aimed at complete beginners and covering the basic setup of the most common functionality.
 

--- a/Documentation/HowToGuides/README.md
+++ b/Documentation/HowToGuides/README.md
@@ -1,4 +1,6 @@
-[Home](../../README.md) &gt; How-to Guides
+&gt; [Home](../../README.md)
+
+# How-to Guides
 
 Step by step instructions on how to set up specific features offered by VRTK.
 

--- a/Documentation/Reference/README.md
+++ b/Documentation/Reference/README.md
@@ -1,4 +1,6 @@
-[Home](../../README.md) &gt; Reference
+&gt; [Home](../../README.md)
+
+# Reference
 
 API documentation for the codebase.
 

--- a/Documentation/Tutorials/README.md
+++ b/Documentation/Tutorials/README.md
@@ -1,4 +1,6 @@
-[Home](../../README.md) &gt; Tutorials
+&gt; [Home](../../README.md)
+
+# Tutorials
 
 Small to medium projects that go from an empty state to a completed goal that shows how to use features within VRTK to build specific solutions.
 

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -111,6 +111,12 @@ body {
       @media print, screen and (max-width: 1300px) {
         margin-left: $sml-side-margin-left;
       }
+
+      ul {
+        li.tag-h1 {
+          display: none;
+        }
+      }
     }
 
     section {


### PR DESCRIPTION
A new layout structure where the page title is no longer in the link
header but instead is a H1 tag and the titles of the actual guides have
been changed to make it more readable.

The styles have been updated to hide the H1 tag from the nav menu as
this isn't considered a page section but rather the page title so
doesn't need linking back to.