### PR TITLE
fix(HowToGuides): move introduction header under guide stats

### DIFF
--- a/Documentation/HowToGuides/Basics/AddingTheUnityXRCameraRig/README.md
+++ b/Documentation/HowToGuides/Basics/AddingTheUnityXRCameraRig/README.md
@@ -2,13 +2,13 @@
 
 # Adding The UnityXRCameraRig
 
-## Introduction
-
 > * Level: Beginner
 >
 > * Reading Time: 2 minutes
 >
 > * Checked with: Unity 2018.3.6f1
+
+## Introduction
 
 The UnityXR CameraRig helper prefab provides a camera that tracks the HMD rotation and position along with any available XR controllers.
 


### PR DESCRIPTION
The Introduction header has now been moved under the guide stats as
the stats aren't really part of the introduction as the text is really
the introduction to the guide.