### PR TITLE
fix(general): ensure spellings are correct and in American English

### DIFF
--- a/Documentation/HowToGuides/Actions/AddingAUnityAxisAction/README.md
+++ b/Documentation/HowToGuides/Actions/AddingAUnityAxisAction/README.md
@@ -15,9 +15,9 @@ Unity Axis Actions tie into the Unity Input Manager and emit events when a defin
 * Unity 1D Axis: listens for changes on a single axis and emits a float value for the axis changes.
 * Unity 2D Axis: listens for changes on a two axes and emits a Vector2 value combining both axis changes.
 
-A Unity Axis Action is derrived from a [Zinnia.Unity] Action and therefore can be injected into any VRTK prefab that requires varying float data (e.g. touchpad movement).
+A Unity Axis Action is derived from a [Zinnia.Unity] Action and therefore can be injected into any VRTK prefab that requires varying float data (e.g. touchpad movement).
 
-VRTK will ask via a popup window on first load of the Unity project whether to attempt to auto create some Unity axis input mappings. If this is accepted then default axis data for left and right controller touchpad/thumbsticks, grip and trigger axes will be created.
+VRTK will ask via a pop up window on first load of the Unity project whether to attempt to auto create some Unity axis input mappings. If this is accepted then default axis data for left and right controller touchpad/thumbsticks, grip and trigger axes will be created.
 
 ## Useful definitions
 
@@ -38,7 +38,7 @@ Expand the `Axes` collapsed item if necessary and confirm there are some VRTK ax
 
 ![VRTK Axis Entries](assets/images/VRTKAxisEntries.png)
 
-If the VRTK axis entries don't appear, then the VRTK popup window can be accessed by selecting `Main Menu -> Window -> VRTK -> Manage Input Mappings`.
+If the VRTK axis entries don't appear, then the VRTK pop up window can be accessed by selecting `Main Menu -> Window -> VRTK -> Manage Input Mappings`.
 
 The VRTK axis input mappings relate to the standard axes outlined at the [Unity Input for OpenVR Controllers].
 

--- a/Documentation/HowToGuides/Actions/AddingAUnityButtonAction/README.md
+++ b/Documentation/HowToGuides/Actions/AddingAUnityButtonAction/README.md
@@ -12,9 +12,9 @@
 
 Unity Button Actions tie into the Unity Input Manager and emit events when a defined Input button is pressed and released.
 
-A Unity Button Action is derrived from a [Zinnia.Unity] Action and therefore can be injected into any VRTK prefab that requires an initiating action (e.g. pointer activation).
+A Unity Button Action is derived from a [Zinnia.Unity] Action and therefore can be injected into any VRTK prefab that requires an initiating action (e.g. pointer activation).
 
-VRTK comes with some prebuilt prefabs containing common button mappings for OpenVR and Oculus controllers.
+VRTK comes with some pre-built prefabs containing common button mappings for OpenVR and Oculus controllers.
 
 ## Useful definitions
 
@@ -84,7 +84,7 @@ Play the Unity scene and press the Right Controller Menu Button and the `Floor` 
 
 ### Step 6
 
-Let's create a custom Unity Button Action to do the same action as outlined aboved but based on a keyboard press.
+Let's create a custom Unity Button Action to do the same action as outlined above but based on a keyboard press.
 
 Create an Empty GameObject in the Unity Hierarchy then click the `Add Component` button and select the `Unity Button Action` component.
 

--- a/Documentation/HowToGuides/CameraRigs/AddingTheSimulatedCameraRig/README.md
+++ b/Documentation/HowToGuides/CameraRigs/AddingTheSimulatedCameraRig/README.md
@@ -10,7 +10,7 @@
 
 ## Introduction
 
-The Simulated CameraRig prefab provides a faux setup that requires no XR hardware to develop and build with. It creates a pseudo headset and controllers that can be manipulated via the mouse and keyboard, which helps testing and building virtual environments without the need for actual hardware to be plugged in.
+The Simulated CameraRig prefab provides a simulated setup that requires no XR hardware to develop and build with. It creates a pseudo headset and controllers that can be manipulated via the mouse and keyboard, which helps testing and building virtual environments without the need for actual hardware to be plugged in.
 
 The outcome of this guide is to learn how to add the Simulated CameraRig prefab to the scene and configure it along with a TrackedAlias prefab.
 

--- a/Documentation/HowToGuides/Interactions/AddingAnInteractable/README.md
+++ b/Documentation/HowToGuides/Interactions/AddingAnInteractable/README.md
@@ -10,11 +10,11 @@
 
 ## Introduction
 
-An `Interactable` prefab provides GameObject that can be interacted with in the virutal world via an `Interactor` prefab. Interactable GameObjects can be notified of actionss that the Interactor is performing such as being touched by an Interactor or reacting to actions such as a grab button being pressed.
+An `Interactable` prefab provides GameObject that can be interacted with in the virtual world via an `Interactor` prefab. Interactable GameObjects can be notified of actions that the Interactor is performing such as being touched by an Interactor or reacting to actions such as a grab button being pressed.
 
 There are a number of different `Interactable` prefabs on offer, but for this example we'll focus on setting up the `Interactable.Primary_Grab.Secondary_Swap` prefab, which is the most common use case for an Interactable GameObject.
 
-By default, Interactable GameObjects can usually perform two actions depending on which Interactor is acting upon them. A common use case is a scene with a Left and Right Controller, both capable of grabbing the Interactable GameObject and carrying it in some way, the first grab attempt from an Interactor is called the `Primary Grab Action` and whilst this is occuring any second grab attempt from a different Interactor is called the `Secondary Grab Action`.
+By default, Interactable GameObjects can usually perform two actions depending on which Interactor is acting upon them. A common use case is a scene with a Left and Right Controller, both capable of grabbing the Interactable GameObject and carrying it in some way, the first grab attempt from an Interactor is called the `Primary Grab Action` and whilst this is occurring any second grab attempt from a different Interactor is called the `Secondary Grab Action`.
 
 This guide will show how to set up an `Interactable` prefab that we can grab with either of our controllers and when we grab it with the other controller, the Interactable GameObject will swap hands as if we had passed the GameObject between our virtual hands.
 
@@ -51,7 +51,7 @@ Expand the VRTK directory in the Unity Project window until the `VRTK -> Prefabs
 
 We're going to change the look of the `Interactable.Primary_Grab.Secondary_Swap` GameObject as by default it's just a `1 x 1 x 1` Cube, which will be very big in our virtual world.
 
-Expand the `Interactable.Primary_Grab.Secondary_Swap` GameObject in the Unity Hierarchy window until the `Meshes -> DefaultMesh` GameObject is visible. We can add a new mesh or collection of meshes under the `Meshes` GameObject and simply set the `Meshes -> DefaultMesh` GameObject to inactive to hide it from the scene, or we can simply change the paramters on the components found on the `Meshes -> DefaultMesh` GameObject.
+Expand the `Interactable.Primary_Grab.Secondary_Swap` GameObject in the Unity Hierarchy window until the `Meshes -> DefaultMesh` GameObject is visible. We can add a new mesh or collection of meshes under the `Meshes` GameObject and simply set the `Meshes -> DefaultMesh` GameObject to inactive to hide it from the scene, or we can simply change the parameters on the components found on the `Meshes -> DefaultMesh` GameObject.
 
 For this example, we'll just change the `Meshes -> DefaultMesh` to reduce the size of the cube. With the `Meshes -> DefaultMesh` GameObject selected, change the `Transform` component properties to:
 

--- a/Documentation/HowToGuides/Interactions/AddingAnInteractor/README.md
+++ b/Documentation/HowToGuides/Interactions/AddingAnInteractor/README.md
@@ -44,7 +44,7 @@ Drag and drop the `Interactor` prefab to be a child of the `LeftControllerAlias`
 
 Select the `Interactor` prefab in the Unity Hierarchy under the `LeftControllerAlias` GameObject and change the `Interactor Facade` component to configure the base functionality of the Interactor.
 
-We need to specify an action that initiates the Interactor's Grab notificaiton. The `Grab Action` parameter on the `Interactor Facade` allows us to provide a `Boolean Action` to initiate the Grab function of the Interactor.
+We need to specify an action that initiates the Interactor's Grab notification. The `Grab Action` parameter on the `Interactor Facade` allows us to provide a `Boolean Action` to initiate the Grab function of the Interactor.
 
 In the [Converting A Float Action To A Boolean Action](../../Actions/ConvertingAFloatActionToABooleanAction/README.md) guide, we learned how to convert a controller axis value to a boolean value so we can initiate actions such as grabbing when a controller axis reaches a certain limit. This is ideal, as for this example we'll set up pressing the trigger axis down on the controller will initiate the Grab action.
 
@@ -64,11 +64,11 @@ Now we should have a `LeftTriggerPressed` GameObject in the Unity Hierarchy wind
 
 When an Interactor grabs an interactable object, it is usually required that the velocity that the Interactor is moving at can be applied to the interactable object. For example, if we were to pick up an interactable object and throw it, then we would want the velocity that we're moving our virtual controller at to be applied to the interactable object so we can control the power of the throw.
 
-The `Velocity Tracker` paramter on the `Interactor Facade` component allows us to specify a velocity tracking component that will provide the relevant velocity data. Fortunately, our `TrackedAlias` prefab already comes with the relevant `Velocity Tracker` components on the relevant aliases that can move freely in the virtual world such as the Headset, Left Controller and Right Controller.
+The `Velocity Tracker` parameter on the `Interactor Facade` component allows us to specify a velocity tracking component that will provide the relevant velocity data. Fortunately, our `TrackedAlias` prefab already comes with the relevant `Velocity Tracker` components on the relevant aliases that can move freely in the virtual world such as the Headset, Left Controller and Right Controller.
 
-Drag and drop the `TrackedAlias -> Aliases -> LeftControllerAlias` GameObject into the `Velocity Tracker` paramter on the `Interactor Facade` to set the interactor to track velocities from our Left Controller.
+Drag and drop the `TrackedAlias -> Aliases -> LeftControllerAlias` GameObject into the `Velocity Tracker` parameter on the `Interactor Facade` to set the interactor to track velocities from our Left Controller.
 
-![Drag And Drop Left Controller Alias To Velocity Tracker Paramter](assets/images/DragAndDropLeftControllerAliasToVelocityTrackerParamter.png)
+![Drag And Drop Left Controller Alias To Velocity Tracker Parameter](assets/images/DragAndDropLeftControllerAliasToVelocityTrackerParamter.png)
 
 > Note: Be sure to do the same with the `RightControllerAlias` GameObject and the `RightControllerAlias -> Interactor` prefab.
 

--- a/Documentation/HowToGuides/Locomotion/AddingATeleporter/README.md
+++ b/Documentation/HowToGuides/Locomotion/AddingATeleporter/README.md
@@ -60,7 +60,7 @@ This tells the Teleporter that when we teleport, we want to move the Play Area t
 
 When the `Target` is teleported, the destination location will become the new central position of the `Target` GameObject. Because our virtual Play Area represents our real world Play Area, this means that if the user walks around their real world Play Area then their position is actually offset inside the Play Area.
 
-This can have an effect when teleporting the user because the user may actually expect to end up standing exactly on the spot where they marked as the destination location. If we just move the Play Area GameObject to match the destination location then the user will still be offset from that destination location and not end up where they expcted.
+This can have an effect when teleporting the user because the user may actually expect to end up standing exactly on the spot where they marked as the destination location. If we just move the Play Area GameObject to match the destination location then the user will still be offset from that destination location and not end up where they expected.
 
 ![Diagram Of How Teleport Location May Require An Offset](assets/images/DiagramOfHowTeleportLocationMayRequireAnOffset.png)
 

--- a/Documentation/Reference/README.md
+++ b/Documentation/Reference/README.md
@@ -2,6 +2,6 @@
 
 # Reference
 
-API documentation for the codebase.
+API documentation for the code-base.
 
 ### Categories coming soon

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Common problems and solutions in spatial computing explained along with how VRTK
 
 ### Reference
 
-API documentation for the codebase.
+API documentation for the code-base.
 
 * [View Reference](Documentation/Reference/README.md)
 


### PR DESCRIPTION
A number of spelling errors have been corrected and words that have
been spelt in English have been converted to American English just
to be consistent with the guidelines for the codebase.