### PR TITLE
fix(Tutorials): remove requirement for .Net 4.x for Oculus Integration

### DIFF
--- a/Documentation/Tutorials/WorkingWith3rdPartySDKs/UsingOculusIntegration/README.md
+++ b/Documentation/Tutorials/WorkingWith3rdPartySDKs/UsingOculusIntegration/README.md
@@ -6,7 +6,5 @@ Oculus Integration is the official SDK from [Oculus](https://developer.oculus.co
 
 Go to the Unity Asset Store by selecting `Main Menu -> Window -> Asset Store` or pressing `CTRL + 9` and search for `Oculus Integration`. Alternatively, click this direct link to [Oculus Integration](https://assetstore.unity.com/packages/tools/integration/oculus-integration-82022) on the Unity Asset Store. Download and import the Oculus Integration Unity Asset into your project.
 
-> Note: Oculus Integration requires the Unity software API Compatibility Level set to `.Net 4.x`. See [this forum post](https://forums.oculusvr.com/developer/discussion/73172/oculus-integration-for-unity-v1-34-01-31-19) for more details.
-
 ### [Working With The OVRCameraRig](WorkingWithTheOVRCameraRig/README.md)
 ### [Creating An OVR Velocity Tracker](CreatingAnOVRVelocityTracker/README.md)


### PR DESCRIPTION
It seems that Oculus Integration no longer requires the API
Compatibility Level set to .Net 4.x so this notice has been removed
from the documentation.